### PR TITLE
docs: update suggested version to be the latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ jobs:
       - name: Install dependencies
         run: yarn install # or npm ci if you use npm and have the package-lock.json file
 
-      - uses: CatChen/eslint-suggestion-action@v2
+      - uses: CatChen/eslint-suggestion-action@v4
         with:
           request-changes: true # optional
           fail-check: false # optional


### PR DESCRIPTION
You're getting a few inbounds about people using outdated versions, likely due to documentation issues (See #928 and #1689)